### PR TITLE
Review bot.php file

### DIFF
--- a/bot.php
+++ b/bot.php
@@ -219,15 +219,31 @@ function bootstrapDatabase(PDO $pdo): void {
          used_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
          FOREIGN KEY (code_id) REFERENCES discount_codes(id) ON DELETE CASCADE
      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;");
-     $pdo->exec("CREATE TABLE IF NOT EXISTS discount_code_blocked_countries (
-         id INT AUTO_INCREMENT PRIMARY KEY,
-         code_id INT NOT NULL,
-         country VARCHAR(128) NOT NULL,
-         UNIQUE KEY uq_code_country (code_id, country),
-         FOREIGN KEY (code_id) REFERENCES discount_codes(id) ON DELETE CASCADE
-     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;");
- 
-     // Seed default buttons if not present
+           $pdo->exec("CREATE TABLE IF NOT EXISTS discount_code_blocked_countries (
+          id INT AUTO_INCREMENT PRIMARY KEY,
+          code_id INT NOT NULL,
+          country VARCHAR(128) NOT NULL,
+          UNIQUE KEY uq_code_country (code_id, country),
+          FOREIGN KEY (code_id) REFERENCES discount_codes(id) ON DELETE CASCADE
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;");
+  
+      // AI Analysis jobs
+      $pdo->exec("CREATE TABLE IF NOT EXISTS ai_analysis_jobs (
+          id INT AUTO_INCREMENT PRIMARY KEY,
+          attacker_user_id INT NULL,
+          defender_user_id INT NULL,
+          kind VARCHAR(64) NOT NULL,
+          status ENUM('queued','running','done','failed') NOT NULL DEFAULT 'queued',
+          model VARCHAR(64) NULL,
+          payload_json LONGTEXT NULL,
+          result_json LONGTEXT NULL,
+          step_index INT NOT NULL DEFAULT 0,
+          next_step_at DATETIME NULL,
+          last_error TEXT NULL,
+          created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;");
+  
+      // Seed default buttons if not present
 $defaults = [
         ['army','لشکر کشی'],
         ['missile','حمله موشکی'],


### PR DESCRIPTION
Add handler for 'set_flag' button and update admin notification texts.

The 'set_flag' button in the admin user profile was non-functional due to a missing handler. Admin notifications for user submissions previously displayed raw section keys (e.g., 'army'), which has been updated to show the localized button titles for better clarity.

---
<a href="https://cursor.com/background-agent?bcId=bc-e6732682-c4e1-40b7-b487-41ad4ad4fbee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e6732682-c4e1-40b7-b487-41ad4ad4fbee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

