### PR TITLE
Fix bot media lock permission error

### DIFF
--- a/Source/bot.php
+++ b/Source/bot.php
@@ -724,7 +724,7 @@ elseif (isset($update->message) && $from_id != $Dev && $data['feed'] == null && 
 		}
 	}
 	if (isset($message->text)) {
-		if ($data['lock']['text'] != '✅') {
+		if ($data['lock']['text'] == '✅') {
 			$checklink = CheckLink($text);
 			$checkfilter = CheckFilter($text);
 			if ($checklink != true) {
@@ -752,7 +752,7 @@ elseif (isset($update->message) && $from_id != $Dev && $data['feed'] == null && 
 		goto tabliq;
 	}
 	if (isset($message->photo)) {
-		if ($data['lock']['photo'] != '✅') {
+		if ($data['lock']['photo'] == '✅') {
 			$get = Forward($Dev, $chat_id, $message_id);
 			if (!isset($get['result']['forward_from'])  || isset($update->message->forward_from) || isset($update->message->forward_from_chat)) {
 				$msg_ids = json_decode(file_get_contents('msg_ids.txt'), true);
@@ -767,7 +767,7 @@ elseif (isset($update->message) && $from_id != $Dev && $data['feed'] == null && 
 		goto tabliq;
 	}
 	if (isset($message->video)) {
-		if ($data['lock']['video'] != '✅') {
+		if ($data['lock']['video'] == '✅') {
 			$get = Forward($Dev, $chat_id, $message_id);
 			if (!isset($get['result']['forward_from'])  || isset($update->message->forward_from) || isset($update->message->forward_from_chat)) {
 				$msg_ids = json_decode(file_get_contents('msg_ids.txt'), true);
@@ -782,7 +782,7 @@ elseif (isset($update->message) && $from_id != $Dev && $data['feed'] == null && 
 		goto tabliq;
 	}
 	if (isset($message->voice)) {
-		if ($data['lock']['voice'] != '✅') {
+		if ($data['lock']['voice'] == '✅') {
 			$get = Forward($Dev, $chat_id, $message_id);
 			if (!isset($get['result']['forward_from']) || isset($update->message->forward_from) || isset($update->message->forward_from_chat)) {
 				$msg_ids = json_decode(file_get_contents('msg_ids.txt'), true);
@@ -797,7 +797,7 @@ elseif (isset($update->message) && $from_id != $Dev && $data['feed'] == null && 
 		goto tabliq;
 	}
 	if (isset($message->audio)) {
-		if ($data['lock']['audio'] != '✅') {
+		if ($data['lock']['audio'] == '✅') {
 			$get = Forward($Dev, $chat_id, $message_id);
 			$msg_ids = json_decode(file_get_contents('msg_ids.txt'), true);
 						$msg_ids[$get['result']['message_id']] = $from_id;
@@ -811,7 +811,7 @@ elseif (isset($update->message) && $from_id != $Dev && $data['feed'] == null && 
 		goto tabliq;
 	}
 	if (isset($message->sticker)) {
-		if ($data['lock']['sticker'] != '✅') {
+		if ($data['lock']['sticker'] == '✅') {
 			$get = Forward($Dev, $chat_id, $message_id);
 			$msg_ids = json_decode(file_get_contents('msg_ids.txt'), true);
 						$msg_ids[$get['result']['message_id']] = $from_id;
@@ -824,7 +824,7 @@ elseif (isset($update->message) && $from_id != $Dev && $data['feed'] == null && 
 		goto tabliq;
 	}
 	if (isset($message->document)) {
-		if ($data['lock']['document'] != '✅') {
+		if ($data['lock']['document'] == '✅') {
 			$get = Forward($Dev, $chat_id, $message_id);
 			if (!isset($get['result']['forward_from']) || isset($update->message->forward_from) || isset($update->message->forward_from_chat)) {
 				$msg_ids = json_decode(file_get_contents('msg_ids.txt'), true);
@@ -873,7 +873,7 @@ elseif (isset($update->message) && $from_id != $Dev && $data['feed'] != null && 
 		}
 	}
 	if (isset($message->text)) {
-		if ($data['lock']['text'] != '✅') {
+		if ($data['lock']['text'] == '✅') {
 			$checklink = CheckLink($text);
 			$checkfilter = CheckFilter($text);
 			if ($checklink != true) {
@@ -884,8 +884,8 @@ elseif (isset($update->message) && $from_id != $Dev && $data['feed'] != null && 
 						$msg_ids[$get['result']['message_id']] = $from_id;
 						file_put_contents('msg_ids.txt', json_encode($msg_ids));
 						//sendMessage($data['feed'], "👤 فرستنده : [$from_id](tg://user?id=$from_id)", 'markdown');
-					}
-					sendMessage($chat_id, "$done", 'html' , $message_id, $button_user);
+			}
+			sendMessage($chat_id, "$done", 'html' , $message_id, $button_user);
 				}
 			}
 			if ($checklink == true) {
@@ -900,7 +900,7 @@ elseif (isset($update->message) && $from_id != $Dev && $data['feed'] != null && 
 		goto tabliq;
 	}
 	if (isset($message->photo)) {
-		if ($data['lock']['photo'] != '✅') {
+		if ($data['lock']['photo'] == '✅') {
 			$get = Forward($data['feed'], $chat_id, $message_id);
 			if (!isset($get['result']['forward_from']) || isset($update->message->forward_from) || isset($update->message->forward_from_chat)) {
 				$msg_ids = json_decode(file_get_contents('msg_ids.txt'), true);
@@ -915,7 +915,7 @@ elseif (isset($update->message) && $from_id != $Dev && $data['feed'] != null && 
 		goto tabliq;
 	}
 	if (isset($message->video)) {
-		if ($data['lock']['video'] != '✅') {
+		if ($data['lock']['video'] == '✅') {
 			$get = Forward($data['feed'], $chat_id, $message_id);
 			if (!isset($get['result']['forward_from']) || isset($update->message->forward_from) || isset($update->message->forward_from_chat)) {
 				$msg_ids = json_decode(file_get_contents('msg_ids.txt'), true);
@@ -930,7 +930,7 @@ elseif (isset($update->message) && $from_id != $Dev && $data['feed'] != null && 
 		goto tabliq;
 	}
 	if (isset($message->voice)) {
-		if ($data['lock']['voice'] != '✅') {
+		if ($data['lock']['voice'] == '✅') {
 			$get = Forward($data['feed'], $chat_id, $message_id);
 			if (!isset($get['result']['forward_from']) || isset($update->message->forward_from) || isset($update->message->forward_from_chat)) {
 				$msg_ids = json_decode(file_get_contents('msg_ids.txt'), true);
@@ -945,7 +945,7 @@ elseif (isset($update->message) && $from_id != $Dev && $data['feed'] != null && 
 		goto tabliq;
 	}
 	if (isset($message->audio)) {
-		if ($data['lock']['audio'] != '✅') {
+		if ($data['lock']['audio'] == '✅') {
 			$get = Forward($data['feed'], $chat_id, $message_id);
 			$msg_ids = json_decode(file_get_contents('msg_ids.txt'), true);
 						$msg_ids[$get['result']['message_id']] = $from_id;
@@ -958,7 +958,7 @@ elseif (isset($update->message) && $from_id != $Dev && $data['feed'] != null && 
 		goto tabliq;
 	}
 	if (isset($message->sticker)) {
-		if ($data['lock']['sticker'] != '✅') {
+		if ($data['lock']['sticker'] == '✅') {
 			$get = Forward($data['feed'], $chat_id, $message_id);
 			$msg_ids = json_decode(file_get_contents('msg_ids.txt'), true);
 						$msg_ids[$get['result']['message_id']] = $from_id;
@@ -971,7 +971,7 @@ elseif (isset($update->message) && $from_id != $Dev && $data['feed'] != null && 
 		goto tabliq;
 	}
 	if (isset($message->document)) {
-		if ($data['lock']['document'] != '✅') {
+		if ($data['lock']['document'] == '✅') {
 			$get = Forward($data['feed'], $chat_id, $message_id);
 			if (!isset($get['result']['forward_from']) || isset($update->message->forward_from) || isset($update->message->forward_from_chat)) {
 				$msg_ids = json_decode(file_get_contents('msg_ids.txt'), true);

--- a/Source/handler.php
+++ b/Source/handler.php
@@ -861,7 +861,7 @@ function replace(string $text)
 ##----------------------
 function CheckLink($text) {
 	global $data;
-	if ($data['lock']['link'] == '✅') {
+	if ($data['lock']['link'] != '✅') {
 		if (stripos($text, "t.me") !== false || stripos($text, "http") !== false || stripos($text, "www.") !== false) {
 			return true;
 		}


### PR DESCRIPTION
Inverted the conditional logic for media, text, and link locks in `Source/bot.php` and `Source/handler.php`.

The previous implementation incorrectly processed lock states. This change aligns the bot's behavior so that content is allowed when a lock is `✅` and blocked when a lock is `❌`.

---
<a href="https://cursor.com/background-agent?bcId=bc-f65a8e22-5fc2-4d6a-be9f-83f187b5ad85">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f65a8e22-5fc2-4d6a-be9f-83f187b5ad85">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

